### PR TITLE
Turn off VCR after running tests

### DIFF
--- a/lib/scraper_test.rb
+++ b/lib/scraper_test.rb
@@ -23,6 +23,8 @@ module ScraperTest
           c.hook_into :webmock
         end
 
+        Minitest.after_run { VCR.turn_off! }
+
         describe 'Scraper tests' do
           it 'should contain the expected data' do
             # TODO: Make this configurable


### PR DESCRIPTION
This adds a Minitest `after_run` hook which runs after the whole suite has finished and turns off VCR.

Fixes #2 