### PR TITLE
Rename rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Then you can drop a YAML file into the `test/data/` directory the looks like the
 
 This will create a new instance of the `ExamplePage` class and then pass it a `Scraped::Response` for the `:url`. It will then assert that the `ExamplePage#to_h` method returns the same as the `:to_h:` hash specifies in the YAML.
 
+### Running the tests
+
+To actually test the YAML files you've written you'll need to run the `test:data` rake task:
+
+    bundle exec rake test:data
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/scraper_test.rb
+++ b/lib/scraper_test.rb
@@ -4,7 +4,7 @@ module ScraperTest
   class RakeTask < ::Rake::TaskLib
     attr_reader :name
 
-    def initialize(name = :test)
+    def initialize(name = 'test:data')
       @name = name
     end
 


### PR DESCRIPTION
This changes the name of the rake task that ships with this library from `test` to `test:data`. This will prevent it from conflicting with rake's own `test` task.

Fixes #7 