### PR TITLE
Fix Rubocop magic comments offence

### DIFF
--- a/scraper_test.gemspec
+++ b/scraper_test.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'scraper_test/version'


### PR DESCRIPTION
This fixes a new Rubocop offence that requires a blank line after "magic" comments.

Similar problem to https://github.com/everypolitician/scraped/issues/78, which was fixed in https://github.com/everypolitician/scraped/pull/80.