### PR TITLE
Extract setup methods from install_tasks

### DIFF
--- a/scraper_test.gemspec
+++ b/scraper_test.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-around'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'scraped'
 end

--- a/scraper_test.gemspec
+++ b/scraper_test.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'vcr', '>= 3.0.3'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'minitest-around'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.47'
 end

--- a/test/cassettes/lky_htm.yml
+++ b/test/cassettes/lky_htm.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.legco.gov.hk/general/english/members/yr16-20/lky.htm
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 May 2017 13:44:22 GMT
+      Server:
+      - Apache/2.2.3 (Red Hat)
+      Last-Modified:
+      - Thu, 22 Dec 2016 09:17:57 GMT
+      Etag:
+      - '"2a600ab-185c-5443bbeb75b40"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '6236'
+      X-Ua-Compatible:
+      - IE=edge
+      Cache-Control:
+      - max-age=0, private, no-store, no-cache, must-revalidate
+      Connection:
+      - close
+      Content-Type:
+      - text/html
+      Set-Cookie:
+      - BIGipServerWeb_80_pool=352400138.20480.0000; path=/
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\r\n\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">
+        \r\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\r\n
+        \ <head>\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"
+        />    \r\n    <meta http-equiv=\"cache-control\" content=\"no-cache\" />\r\n
+        \   <meta http-equiv=\"pragma\" content=\"no-cache\" />\r\n    <meta http-equiv=\"expires\"
+        content=\"0\" />\r\n    <meta name=\"keywords\" content=\"\" />\r\n    <meta
+        name=\"description\" content=\"\" />\r\n    <meta name=\"extendedkeyword\"
+        content=\"Hon Andrew LEUNG Kwan-yuen, GBS, JP\" />    \r\n    <title>Legislative
+        Council of the Hong Kong Special Administrative Region - Members' Biographies
+        ::Hon Andrew LEUNG Kwan-yuen, GBS, JP</title>\r\n<!-- NOT IMPORT START -->\t\r\n
+        \   <link type=\"text/css\" title=\"style_s\" rel=\"stylesheet\" href=\"/scripts/style.css\"
+        />\r\n    <link type=\"text/css\" title=\"style_m\" rel=\"alternate stylesheet\"
+        href=\"/scripts/style_medium.css\" />\r\n    <link type=\"text/css\" title=\"style_l\"
+        rel=\"alternate stylesheet\" href=\"/scripts/style_large.css\" />\r\n    <link
+        type=\"text/css\" rel=\"stylesheet\" href=\"/scripts/common.css\" />\r\n    <!--
+        favicon -->\r\n    <link href=\"/favicon.ico\" rel=\"icon\" type=\"image/x-icon\"
+        />\r\n    <link href=\"/favicon.ico\" rel=\"shortcut icon\" type=\"image/x-icon\"
+        />\r\n    <!-- iphone icon -->\r\n    <link rel=\"apple-touch-icon\" href=\"/apple-touch-icon.png\"
+        />\t\r\n    <script type=\"text/javascript\">var skinId = 1; </script>\r\n
+        \   <script type=\"text/javascript\" src=\"/scripts/jquery-1.6.2.min.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/_sysjs/menudata.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/scripts/detect.js\"></script>\r\n
+        \   <script type=\"text/javascript\" src=\"/scripts/includejs.js\"></script>\r\n<!--
+        NOT IMPORT END -->\r\n\r\n\r\n\r\n\r\n\r\n</head>\r\n  <body>\r\n    <div
+        id=\"body\" class=\"body\">\r\n      <script type=\"text/JavaScript\">skipwrapper();</script>\r\n
+        \     <div id=\"top\">\r\n        <div class=\"mainheader\"><script type=\"text/JavaScript\">clf_header();</script></div>\r\n
+        \       <div class=\"mainmenu\"><script type=\"text/JavaScript\">mainmenu();</script></div>\r\n
+        \     </div>\r\n      <div id=\"info\">\r\n\t\t<div id=\"submenu\" class=\"submenu\">\r\n\t\t\t<script
+        type=\"text/javascript\">submenu(); sectionImage();</script>\r\n\t\t</div>\r\n\t\t<div
+        id=\"right-content-container\">\r\n\t\t\t<div id=\"left-menu-container\">\r\n\t\t\t\t<div
+        id=\"left-menu\">\r\n\t\t\t\t\t<div id=\"leftmenubg_top\">\r\n\t\t\t\t\t\t<script
+        type=\"text/javascript\">setLeftmenuImg(); leftmenu();</script><div id=\"rcblock\"></div>\t\t\r\n\t\t\t\t\t</div>\t\t\t\r\n\t\t\t\t</div>\t\t\r\n\t\t\t\t<div
+        id=\"right-content\" class=\"right-content\">\r\n\t\t\t\t\t<div class=\"bggrey\"><img
+        src=\"/skin/1/images/spacer.gif\" width=\"1\" height=\"1\" alt=\"\" /></div>\t\t\t\t\r\n\t\t\t\t\t\t\t\t\r\n\t\t\t\t\t<div
+        class=\"sub_header\"><script type=\"text/javascript\">pageHeader()</script></div>\r\n\t\t\t\t\t<script
+        type=\"text/javascript\">headerLine();</script>\r\n\t\t\t\t\t<div id=\"_content_\"
+        class=\"content_word\">\t\t\t\t\t\t\r\n<!-- CONTENT START -->\t\r\n<div id=\"container\">\r\n<div>\r\n<!--
+        Photo of Member -->\r\n<!--<img src=\"/images/mem_1620/lky.jpg\" alt=\"Hon
+        Andrew LEUNG Kwan-yuen, GBS, JP\" style=\"float:right;width:129px;border:1px
+        solid #ccc;\" />-->\r\n<img src=\"/images/mem_1620/lky.jpg\" alt=\"Hon Andrew
+        LEUNG Kwan-yuen, GBS, JP\" style=\"float:right;width:201px;border:1px solid
+        #ccc;margin-left:5px;\" />\r\n\r\n<!-- Name of Member -->\r\n<h2>Hon Andrew
+        LEUNG Kwan-yuen, GBS, JP\r\n</h2>\r\n\r\n<!-- Constituency -->\r\n<p><strong>Constituency
+        :</strong></p>\r\n<ul><li>Functional Constituency - Industrial (First)\r\n</li></ul>\r\n\r\n<!--
+        Education and professional qualifications -->\r\n<p><strong>Education and
+        professional qualifications :</strong></p>\r\n<ul>\r\n<li>BSc (Hon), Leeds
+        University\r\n</li><li>Fellow, Textiles Institute \r\n</li><li>Fellow, Clothing
+        and Footwear Institute \r\n</li><li>Honorary Doctor of Business Administration,
+        Coventry University, UK\r\n</li></ul>\r\n\r\n<!-- Occupation -->\r\n<p><strong>Occupation
+        :</strong></p>\r\n<ul>\r\n<li>Merchant\r\n</li></ul>\r\n\r\n<!-- Political
+        affiliation -->\r\n<p><strong>Political affiliation :</strong></p>\r\n<ul>\r\n<li>Business
+        and Professionals Alliance for Hong Kong\r\n</li></ul>\r\n\r\n<!-- Contact
+        Information -->\r\n<table cellspacing=\"2\" cellpadding=\"2\" width=\"100%\">\r\n<tr><td
+        valign=\"top\" nowrap=\"nowrap\" width=\"16%\"><strong>Office address</strong></td>\r\n<td
+        valign=\"top\" width=\"1%\"><strong>:</strong></td>\r\n<td valign=\"top\">\r\nRoom
+        710, Legislative Council Complex,<br />\r\n1 Legislative Council Road, Central,
+        Hong Kong\r\n</td></tr>\r\n\r\n<tr><td valign=\"top\" nowrap=\"nowrap\"><strong>Office
+        telephone</strong></td>\r\n<td valign=\"top\"><strong>:</strong></td>\r\n<td
+        valign=\"top\" class=\"tel\">2537 1339</td></tr>\r\n\r\n<tr><td valign=\"top\"
+        nowrap=\"nowrap\"><strong>Office fax</strong></td>\r\n<td valign=\"top\"><strong>:</strong></td>\r\n<td
+        valign=\"top\" class=\"fax\">2697 8482\r\n</td></tr>\r\n\r\n<tr><td valign=\"top\"
+        nowrap=\"nowrap\"><strong>E-mail</strong></td>\r\n<td valign=\"top\"><strong>:</strong></td>\r\n<td
+        valign=\"top\"><a href=\"mailto:andrewleunglegco@outlook.com\">andrewleunglegco@outlook.com</a>\r\n</td></tr>\r\n\r\n<tr><td
+        valign=\"top\" nowrap=\"nowrap\"><strong>Homepage</strong></td>\r\n<td valign=\"top\"><strong>:</strong></td>\r\n<td
+        valign=\"top\"><a href=\"http://www.andrewkyleung.hk\" target=\"_blank\">http://www.andrewkyleung.hk</a>\r\n</td></tr>\r\n<!--\r\n<tr><td
+        valign=\"top\" nowrap=\"nowrap\"><strong>Homepage or R&eacute;sum&eacute;</strong></td>\r\n<td
+        valign=\"top\"><strong>:</strong></td>\r\n<td valign=\"top\">-\r\n</td></tr>\r\n<tr><td
+        valign=\"top\" nowrap=\"nowrap\"><strong>R&eacute;sum&eacute;</strong></td>\r\n<td
+        valign=\"top\"><strong>:</strong></td>\r\n<td valign=\"top\"><a href=\"-e.pdf\"
+        target=\"_blank\"><img src=\"../../../../images/english/pdf.gif\" alt=\"PDF
+        file\" border=\"0\" /></a>\r\n</td></tr>\r\n-->\r\n</table>\r\n<br /><br />(Information
+        as provided by Member)<br /><br />\r\n</div>\r\n</div>\r\n<!-- CONTENT END
+        -->\t\t\t\t\t\r\n\t\t\t\t\t</div>\r\n\t\t\t\t</div>\r\n\t\t\t</div>\r\n\t\t</div>\r\n\t
+        \ </div>\r\n\t  \r\n      <div id=\"link\" class=\"link\">\r\n\t\t<div class=\"hiddenheader\"></div>\r\n
+        \       <div class=\"link-1\"></div>\r\n        <div class=\"link-2\"></div>\r\n
+        \       <div class=\"link-3\"><script type=\"text/JavaScript\">clf_footer();</script></div>\r\n
+        \       <div class=\"link-4\" align=\"center\"><script type=\"text/JavaScript\">clf_copyright();</script></div>\r\n
+        \     </div>\t  \r\n\t</div>\r\n  </body>\r\n</html>"
+    http_version: 
+  recorded_at: Thu, 04 May 2017 13:44:22 GMT
+recorded_with: VCR 3.0.3

--- a/test/data/member_data.yml
+++ b/test/data/member_data.yml
@@ -1,0 +1,5 @@
+:url: http://www.legco.gov.hk/general/english/members/yr16-20/lky.htm
+:class: DummyClass
+:to_h:
+  :id: yr16-20/lky
+  :term: yr16-20

--- a/test/results_test.rb
+++ b/test/results_test.rb
@@ -1,11 +1,28 @@
 require 'test_helper'
+require 'scraped'
+
+class DummyClass < Scraped::HTML
+  field :id do
+    [term, File.basename(url, '.htm')].join('/')
+  end
+
+  field :term do
+    File.dirname(url).split('/').last
+  end
+end
 
 describe ScraperTest::Results do
   let(:file) { './test/data/member_data.yml' }
   let(:expected) { YAML.load_file(file).to_h[:to_h] }
   let(:results) { ScraperTest::Results.new(file) }
 
+  around { |test| VCR.use_cassette(File.basename(file), &test) }
+
   it 'returns the expected result' do
     results.expected.must_equal expected
+  end
+
+  it 'returns the actual result' do
+    results.actual.must_equal expected
   end
 end

--- a/test/results_test.rb
+++ b/test/results_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+describe ScraperTest::Results do
+  let(:file) { './test/data/member_data.yml' }
+  let(:expected) { YAML.load_file(file).to_h[:to_h] }
+  let(:results) { ScraperTest::Results.new(file) }
+
+  it 'returns the expected result' do
+    results.expected.must_equal expected
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'scraper_test'
 
+require 'minitest/around/spec'
 require 'minitest/autorun'
+require 'vcr'
+require 'webmock'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'test/cassettes'
+  c.hook_into :webmock
+end


### PR DESCRIPTION
This PR is in preparation of https://github.com/everypolitician/scraper_test/pull/16

`install_tasks` has grown quite long. #16 will add further lines of code to the method but doing so will cause it to fail rubocop's line count check.

This PR extracts the `Results` class which takes a yaml test file and returns the actual and expected data.