### PR TITLE
Handle :path field in instructions

### DIFF
--- a/lib/scraper_test.rb
+++ b/lib/scraper_test.rb
@@ -62,6 +62,10 @@ module ScraperTest
       test_data[:to_h] or raise "No to_h supplied in #{filepath.basename}."
     end
 
+    def path
+      test_data[:path]
+    end
+
     private
 
     attr_reader :filename

--- a/scraper_test.gemspec
+++ b/scraper_test.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'scraped'
 end

--- a/test/data/instructions_with_path.yml
+++ b/test/data/instructions_with_path.yml
@@ -1,0 +1,10 @@
+---
+:class: DummyMembersList
+:url: https://www.example.com
+:path:
+  - :upper_house
+  - :members
+  - :id: 1
+:to_h:
+  :id: 1
+  :name: 'Jim'

--- a/test/instructions_test.rb
+++ b/test/instructions_test.rb
@@ -8,6 +8,14 @@ class DummyClass
   end
 end
 
+class DummyMembersList < Scraped::HTML
+  # This is the class referenced in `./data/target_subset_of_members_list_data.yml`.
+  # The instructions file specifies a subset of the data returned by to_h.
+  def to_h
+    { upper_houser: { members: [{ id: 1, name: 'Jim' }, { id: 2, name: 'Joe' }] } }
+  end
+end
+
 describe ScraperTest::Instructions do
   let(:instructions) { ScraperTest::Instructions.new(file) }
 
@@ -60,6 +68,22 @@ describe ScraperTest::Instructions do
 
     it 'raises an error if the class is unkown' do
       -> { instructions.class_to_test }.must_raise NameError
+    end
+  end
+
+  describe 'instructions that specify a target subset of data' do
+    let(:file) { './test/data/instructions_with_path.yml' }
+
+    it 'returns the expected path' do
+      instructions.path.must_equal [:upper_house, :members, { id: 1 }]
+    end
+  end
+
+  describe 'instructions without path' do
+    let(:file) { './test/data/valid_instructions.yml' }
+
+    it 'returns nil for path' do
+      instructions.path.must_be_nil
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'scraped'
 require 'scraper_test'
 
 require 'minitest/autorun'


### PR DESCRIPTION
Part of: https://github.com/everypolitician/scraper_test/issues/13

A future PR (WIP: https://github.com/everypolitician/scraper_test/pull/26) will allow the testing of a subset of the response data.

In anticipation of that PR, this PR provides a way to specify that subset of data. The Instructions class now handles a list that can be used to target the required test data.

Although Instructions does not care about the contents of the `:path` field, it is intended to work like this:

The response data might contain multiple members within an array:
```
{ members: [{id: 1, name: 'Jim' }, { id: 2, name: 'Joe' }] }
```
A list can be specified in the :path field. To target Joe, the array would be:

```YAML
:path:
    - :members
    - :id: 2
```
That is, the path specifies that the test wants a hash containing the id of 2 within the members array.

The path can be used to drill down any number of levels.

```YAML
:houses:
  :lower:
    :members:
      - :id: 1
        :name: David Bowman
      - :id: 2
        :name: Frank Poole
  :upper:
    :members:
      - :id: 1
        :name: Victor Kaminsky
        :notes:
          - Survey Team Leader
          - Deceased
      - :id: 2
        :name: Jack Kimball
        :notes:
          - Geophysicist
          - Deceased
      - :id: 3
        :name: Charles Hunter
        :notes:
          - Astrophysicist
          - Deceased
```

To get at Dr. Kaminsky's notes, the path field would be:
```YAML
  :path:
    - :houses
    - :upper
    - :members
    - :id: 1
    - :notes
```