### PR TITLE
WIP: Extract test class

### DIFF
--- a/lib/scraper_test.rb
+++ b/lib/scraper_test.rb
@@ -62,6 +62,10 @@ module ScraperTest
       test_data[:to_h] or raise "No to_h supplied in #{filepath.basename}."
     end
 
+    def target
+      test_data[:target]
+    end
+
     private
 
     attr_reader :filename

--- a/scraper_test.gemspec
+++ b/scraper_test.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'scraped'
 end

--- a/test/data/instructions_with_invalid_target.yml
+++ b/test/data/instructions_with_invalid_target.yml
@@ -1,0 +1,7 @@
+---
+:class: DummyMembersList
+:url: http://www.example.com
+:target: id
+:to_h:
+  :id: 1
+  :name: 'Jim'

--- a/test/data/instructions_with_path.yml
+++ b/test/data/instructions_with_path.yml
@@ -1,0 +1,10 @@
+---
+:class: DummyMembersList
+:url: https://www.example.com
+:path:
+  - :upper_house
+  - :members
+  - :id: 1
+:to_h:
+  :id: 1
+  :name: 'Jim'

--- a/test/data/instructions_with_target.yml
+++ b/test/data/instructions_with_target.yml
@@ -1,0 +1,8 @@
+---
+:class: DummyMembersList
+:url: https://www.example.com
+:target:
+  :id: 1
+:to_h:
+  :id: 1
+  :name: 'Jim'

--- a/test/data/instructions_with_target_with_invalid_key.yml
+++ b/test/data/instructions_with_target_with_invalid_key.yml
@@ -1,0 +1,8 @@
+---
+:class: DummyMembersList
+:url: http://www.example.com
+:target:
+  :key_not_present: 23
+:to_h:
+  :id: 1
+  :name: 'Jim'

--- a/test/data/instructions_with_target_with_invalid_target.yml
+++ b/test/data/instructions_with_target_with_invalid_target.yml
@@ -1,0 +1,8 @@
+---
+:class: DummyMembersList
+:url: https://www.example.com
+:target:
+  :id: unkown
+:to_h:
+  :id: 1
+  :name: 'Jim'

--- a/test/data/instructions_with_target_with_known_key_with_unknown_value.yml
+++ b/test/data/instructions_with_target_with_known_key_with_unknown_value.yml
@@ -1,10 +1,8 @@
 ---
 :class: DummyMembersList
 :url: https://www.example.com
-:path:
-  - :upper_house
-  - :members
-  - :id: 1
+:target:
+  :id: unkown value
 :to_h:
   :id: 1
   :name: 'Jim'

--- a/test/instructions_test.rb
+++ b/test/instructions_test.rb
@@ -1,21 +1,5 @@
 require 'test_helper'
 
-class DummyClass
-  # This is the class referenced in `./data/valid_instructions.yml`.
-  # For an instructions file to be valid, it must reference a known class.
-  def to_h
-    { id: 34 }
-  end
-end
-
-class DummyMembersList < Scraped::HTML
-  # This is the class referenced in `./data/target_subset_of_members_list_data.yml`.
-  # The instructions file specifies a subset of the data returned by to_h.
-  def to_h
-    { members: [{ id: 1, name: 'Jim' }, { id: 2, name: 'Joe' }] }
-  end
-end
-
 describe ScraperTest::Instructions do
   let(:instructions) { ScraperTest::Instructions.new(file) }
 

--- a/test/instructions_test.rb
+++ b/test/instructions_test.rb
@@ -8,6 +8,14 @@ class DummyClass
   end
 end
 
+class DummyMembersList < Scraped::HTML
+  # This is the class referenced in `./data/target_subset_of_members_list_data.yml`.
+  # The instructions file specifies a subset of the data returned by to_h.
+  def to_h
+    { members: [{ id: 1, name: 'Jim' }, { id: 2, name: 'Joe' }] }
+  end
+end
+
 describe ScraperTest::Instructions do
   let(:instructions) { ScraperTest::Instructions.new(file) }
 
@@ -60,6 +68,22 @@ describe ScraperTest::Instructions do
 
     it 'raises an error if the class is unkown' do
       -> { instructions.class_to_test }.must_raise NameError
+    end
+  end
+
+  describe 'instructions that specify a target subset of data' do
+    let(:file) { './test/data/instructions_with_target.yml' }
+
+    it 'returns the expected target' do
+      instructions.target.must_equal({ id: 1 })
+    end
+  end
+
+  describe 'instructions without target' do
+    let(:file) { './test/data/valid_instructions.yml' }
+
+    it 'returns nil for target' do
+      instructions.target.must_be_nil
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'scraped'
 require 'scraper_test'
 
 require 'minitest/autorun'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,3 +3,19 @@ require 'scraped'
 require 'scraper_test'
 
 require 'minitest/autorun'
+
+class DummyClass < Scraped::HTML
+  # This is the class referenced in `./data/valid_instructions.yml`.
+  # For an instructions file to be valid, it must reference a known class.
+  def to_h
+    { id: 34 }
+  end
+end
+
+class DummyMembersList < Scraped::HTML
+  # This is the class referenced in `./data/target_subset_of_members_list_data.yml`.
+  # The instructions file specifies a subset of the data returned by to_h.
+  def to_h
+    { members: [{ id: 1, name: 'Jim' }, { id: 2, name: 'Joe' }] }
+  end
+end

--- a/test/test_test.rb
+++ b/test/test_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+describe ScraperTest::Test do
+  let(:instructions) { ScraperTest::Instructions.new(file) }
+  let(:subject) { ScraperTest::Test.new(instructions) }
+
+  let(:equality_test) do
+    proc { subject.compare { |actual, expected| actual.must_equal expected } }
+  end
+
+  describe 'Instructions without specified target' do
+    let(:file) { './test/data/valid_instructions.yml' }
+
+    it 'will pass' do
+      equality_test.call
+    end
+  end
+
+  describe 'Test data with specified target' do
+    let(:file) { './test/data/instructions_with_target.yml' }
+
+    it 'will pass' do
+      equality_test.call
+    end
+  end
+
+  describe 'Test data with target key that does not match source data' do
+    let(:file) { './test/data/instructions_with_target_with_invalid_key.yml' }
+
+    it 'will raise the expected error' do
+      err = -> { equality_test.call }.must_raise StandardError
+      err.message.must_equal 'Cannot find {:key_not_present=>23} in response data.'
+    end
+  end
+
+  describe 'Test data with a non-existing key value pair where the key is known' do
+    let(:file) { './test/data/instructions_with_target_with_known_key_with_unknown_value.yml' }
+    
+    it 'will raise the expected error' do
+      err = -> { equality_test.call }.must_raise StandardError
+      err.message.must_equal 'Cannot find {:id=>"unkown value"} in response data.'
+    end
+  end
+
+  describe 'Test data with an invalid path' do
+    let(:file) { './test/data/instructions_with_target_with_invalid_target.yml' }
+
+    it 'will raise the expected error' do
+      err = -> { equality_test.call }.must_raise StandardError
+      err.message.must_equal 'Cannot find {:id=>"unkown"} in response data.'
+    end
+  end
+end


### PR DESCRIPTION
Closes: #13

This PR introduces the `ScraperTest::Test`.

It runs a test to the specifications of the instructions object passed to it. `ScraperTest::Test#run` compares the test data specified in the instructions object with data return by the class, also specified in the instructions object.

It is able to test against a subset of data when the instructions object specifies it.

WIP: I'm not sure I've done the right thing yielding the before and after values to a block in `#compare`. If I'm exposing them in the block, I might as well just expose `#actual` and `#expected` instead. But then again, I'm note sure _that's_ the way to go either. Also, the behaviour of `#actual` when using an invalid paths differs from when it's used with a path with an unknown key/value pair.
