### PR TITLE
Handle target instructions field

### DIFF
--- a/lib/scraper_test.rb
+++ b/lib/scraper_test.rb
@@ -62,6 +62,10 @@ module ScraperTest
       test_data[:to_h] or raise "No to_h supplied in #{filepath.basename}."
     end
 
+    def target
+      test_data[:target]
+    end
+
     private
 
     attr_reader :filename

--- a/scraper_test.gemspec
+++ b/scraper_test.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'scraped'
 end

--- a/test/data/instructions_with_target.yml
+++ b/test/data/instructions_with_target.yml
@@ -1,0 +1,8 @@
+---
+:class: DummyMembersList
+:url: https://www.example.com
+:target:
+  :id: 1
+:to_h:
+  :id: 1
+  :name: 'Jim'

--- a/test/instructions_test.rb
+++ b/test/instructions_test.rb
@@ -8,6 +8,14 @@ class DummyClass
   end
 end
 
+class DummyMembersList < Scraped::HTML
+  # This is the class referenced in `./data/target_subset_of_members_list_data.yml`.
+  # The instructions file specifies a subset of the data returned by to_h.
+  def to_h
+    { members: [{ id: 1, name: 'Jim' }, { id: 2, name: 'Joe' }] }
+  end
+end
+
 describe ScraperTest::Instructions do
   let(:instructions) { ScraperTest::Instructions.new(file) }
 
@@ -60,6 +68,22 @@ describe ScraperTest::Instructions do
 
     it 'raises an error if the class is unkown' do
       -> { instructions.class_to_test }.must_raise NameError
+    end
+  end
+
+  describe 'instructions that specify a target subset of data' do
+    let(:file) { './test/data/instructions_with_target.yml' }
+
+    it 'returns the expected target' do
+      instructions.target.must_equal(id: 1)
+    end
+  end
+
+  describe 'instructions without target' do
+    let(:file) { './test/data/valid_instructions.yml' }
+
+    it 'returns nil for target' do
+      instructions.target.must_be_nil
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'scraped'
 require 'scraper_test'
 
 require 'minitest/autorun'


### PR DESCRIPTION
A future PR (WIP https://github.com/everypolitician/scraper_test/pull/26) will allow the testing of a subset of the response data.

In anticipation of that PR, this commit provides a way to target that subset of data.

Although Instructions does not care about the contents of the :target field, it is intended to work like this:

The response data might contain multiple members within an array:
```
{ members: [{id: 1, name: 'Jim' }, { id: 2, name: 'Joe' }] }
```

To target the first member, we can supply a key value pair:
```YAML
target:
    :id: 1
```

or

```YAML
target:
    :name: 'Jim'
```